### PR TITLE
Wagtail 6.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
         environment:
           PIPENV_VENV_IN_PROJECT: true
           DATABASE_URL: postgresql://root@localhost/circle_test?sslmode=disable
-      - image: cimg/postgres:16.2.0
+      - image: cimg/postgres:16.2
         environment:
           POSTGRES_USER: root
           POSTGRES_DB: circle_test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,8 +13,7 @@ jobs:
           POSTGRES_DB: circle_test
     steps:
       - checkout
-      - run: sudo chown -R circleci:circleci /usr/local/bin
-      - run: sudo chown -R circleci:circleci /usr/local/lib/python3.12/site-packages
+      - run: sudo apt-get update && sudo apt-get install -y python3-pip
       - run:
           command: |
             sudo pip install pipenv

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,18 +3,18 @@ jobs:
   build:
     working_directory: ~/wagtailquickcreate
     docker:
-      - image: circleci/python:3.8.0
+      - image: cimg/python:3.12.1
         environment:
           PIPENV_VENV_IN_PROJECT: true
           DATABASE_URL: postgresql://root@localhost/circle_test?sslmode=disable
-      - image: circleci/postgres:9.6.2
+      - image: cimg/postgres:16.2.0
         environment:
           POSTGRES_USER: root
           POSTGRES_DB: circle_test
     steps:
       - checkout
       - run: sudo chown -R circleci:circleci /usr/local/bin
-      - run: sudo chown -R circleci:circleci /usr/local/lib/python3.8/site-packages
+      - run: sudo chown -R circleci:circleci /usr/local/lib/python3.12/site-packages
       - run:
           command: |
             sudo pip install pipenv

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -13,7 +13,7 @@ jobs:
       matrix:
         include:
           - python: 3.9
-            wagtail: wagtail>=4.1
+            wagtail: wagtail>=5.2
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v3

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -12,11 +12,11 @@ jobs:
     strategy:
       matrix:
         include:
-          - python: 3.9
+          - python: 3.12
             wagtail: wagtail>=5.2
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python }}
           cache: "pip"

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
     packages=find_packages(exclude=['tests*']),
     include_package_data=True,
     install_requires=[
-        'wagtail>=4.1',
+        'wagtail>=5.2',
     ],
     classifiers=[
         'Environment :: Web Environment',
@@ -40,7 +40,7 @@ setup(
         'Programming Language :: Python :: 3.11',
         'Programming Language :: Python :: 3.12',
         'Framework :: Wagtail',
-        'Framework :: Wagtail :: 4',
         'Framework :: Wagtail :: 5',
+        'Framework :: Wagtail :: 6',
     ],
 )

--- a/wagtailquickcreate/templates/wagtailquickcreate/create.html
+++ b/wagtailquickcreate/templates/wagtailquickcreate/create.html
@@ -6,13 +6,15 @@
 
 {% block content %}
     <header class="w-header w-header--merged">
-        <div class="row row-flush">
-            <div class="col">
-                <h1 class="w-header__title">
-                    <img src="{% avatar_url user %}" alt="" class="avatar"/>
-                    Add {{ model_verbose_name }}
-                </h1>
-                <h2>{{ user.get_full_name|default:user.get_username }}</h2>
+        <div class="row">
+            <div class="left">
+                <div class="col">
+                    <h1 class="w-header__title" id="header-title">
+                        <div class="avatar"><img src="{% avatar_url user %}" alt="" /></div>
+                        Add {{ model_verbose_name }}
+                        <span class="w-header__subtitle">{{ user.get_full_name|default:user.get_username }}</span>
+                    </h1>
+                </div>
             </div>
         </div>
     </header>

--- a/wagtailquickcreate/templates/wagtailquickcreate/create.html
+++ b/wagtailquickcreate/templates/wagtailquickcreate/create.html
@@ -28,7 +28,8 @@
 
             {% for page in parent_pages %}
                 <li>
-                    <a href="/admin/pages/add/{{model_app|lower}}/{{page.model|lower}}/{{page.id}}/" class="icon icon-plus-inverse icon-larger">
+                    <a href="/admin/pages/add/{{model_app|lower}}/{{page.model|lower}}/{{page.id}}/">
+                        {% icon name="plus-inverse" classname="default w-mr-1 w-align-middle" %}
                         {% for parent in page.ancestors %}
                             {% if not parent.is_root %}
                                 {{ parent }} >

--- a/wagtailquickcreate/tests/settings.py
+++ b/wagtailquickcreate/tests/settings.py
@@ -19,7 +19,6 @@ INSTALLED_APPS = [
     'wagtail.contrib.routable_page',
     'wagtail.contrib.frontend_cache',
     'wagtail.contrib.settings',
-    'wagtail.contrib.modeladmin',
     'wagtail.contrib.table_block',
     'wagtail.contrib.forms',
     'wagtail.embeds',

--- a/wagtailquickcreate/tests/tests.py
+++ b/wagtailquickcreate/tests/tests.py
@@ -8,39 +8,53 @@ from wagtailquickcreate.tests.standardpages.models import IndexPage
 
 
 class WagtailQuickCreateTests(TestCase, WagtailTestUtils):
-    fixtures = ['wagtailquickcreate/tests/fixtures/test.json']
+    fixtures = ["wagtailquickcreate/tests/fixtures/test.json"]
 
     def setUp(self):
         super().setUp()
         self.login()
         self.home = Page.objects.get(pk=2)
-        self.index = IndexPage(
-            title='Section 1',
-            slug='section-1',
-            introduction='...'
-        )
+        self.index = IndexPage(title="Section 1", slug="section-1", introduction="...")
         self.index_2 = IndexPage(
-            title='Section 2',
-            slug='section-2',
-            introduction='...'
+            title="Section 2", slug="section-2", introduction="..."
         )
         self.home.add_child(instance=self.index)
         self.index.add_child(instance=self.index_2)
 
     def test_admin(self):
-        response = self.client.get(reverse('wagtailadmin_home'))
+        response = self.client.get(reverse("wagtailadmin_home"))
         self.assertEqual(response.status_code, 200)
 
     def test_quickcreate_panel_links(self):
-        response = self.client.get('/admin/')
-        self.assertTrue('Add Image' in str(response.content))
-        self.assertTrue('Add Document' in str(response.content))
-        self.assertTrue('Add Information page' in str(response.content))
+        response = self.client.get("/admin/")
+        self.assertTrue("Add Image" in str(response.content))
+        self.assertTrue("Add Document" in str(response.content))
+        self.assertTrue("Add Information page" in str(response.content))
 
     def test_first_level_index_page_in_shortcut_view(self):
-        response = self.client.get('/admin/quickcreate/create/standardpages/informationpage/')
-        self.assertContains(response, 'Home > <strong>Section 1</strong>', html=True)
+        response = self.client.get(
+            "/admin/quickcreate/create/standardpages/informationpage/"
+        )
+        self.assertContains(
+            response,
+            "Home >\n                            "
+            "\n                        "
+            "\n                        "
+            "<strong>Section 1</strong>",
+        )
 
     def test_second_level_index_in_shortcut_view(self):
-        response = self.client.get('/admin/quickcreate/create/standardpages/informationpage/')
-        self.assertContains(response, 'Home > Section 1 > <strong>Section 2</strong>', html=True)
+        response = self.client.get(
+            "/admin/quickcreate/create/standardpages/informationpage/"
+        )
+        self.assertContains(
+            response,
+            "Home >\n                            "
+            "\n                        "
+            "\n                            "
+            "\n                                "
+            "Section 1 >\n                            "
+            "\n                        "
+            "\n                        "
+            "<strong>Section 2</strong>",
+        )


### PR DESCRIPTION
# Notes

- No significant changes related to Wagtail 6.1

## Wagtail 6.1 upgrade

<details>
<summary>Code review check list</summary>

## Code reviewing a consideration.
Use the tick box to indicate a consideration has been code reviewed as OK

### What’s new
  - [ ] [Universal listings continued](https://docs.wagtail.org/en/latest/releases/6.1.html#universal-listings-continued)
  - [ ] [Information-dense admin interface](https://docs.wagtail.org/en/latest/releases/6.1.html#information-dense-admin-interface)
  - [ ] [Custom per-page-type listings](https://docs.wagtail.org/en/latest/releases/6.1.html#custom-per-page-type-listings)
  - [ ] [Keyboard shortcuts overview](https://docs.wagtail.org/en/latest/releases/6.1.html#keyboard-shortcuts-overview)
  - [ ] [Better guidance for password-protected content](https://docs.wagtail.org/en/latest/releases/6.1.html#better-guidance-for-password-protected-content)
  - [ ] [Favicon images generation](https://docs.wagtail.org/en/latest/releases/6.1.html#favicon-images-generation)
  - [ ] [Cve-2024-32882: permission check bypass when editing a model with per-field restrictions through wagtail.contrib.settings or modelviewset](https://docs.wagtail.org/en/latest/releases/6.1.html#cve-2024-32882-permission-check-bypass-when-editing-a-model-with-per-field-restrictions-through-wagtail-contrib-settings-or-modelviewset)
  - [ ] [Other features](https://docs.wagtail.org/en/latest/releases/6.1.html#other-features)
  - [ ] [Bug fixes](https://docs.wagtail.org/en/latest/releases/6.1.html#bug-fixes)
  - [ ] [Documentation](https://docs.wagtail.org/en/latest/releases/6.1.html#documentation)
  - [ ] [Maintenance](https://docs.wagtail.org/en/latest/releases/6.1.html#maintenance)
### Changes affecting wagtail customizations
  - [ ] [Changes to submissionslistview class](https://docs.wagtail.org/en/latest/releases/6.1.html#changes-to-submissionslistview-class)
  - [ ] [Register_user_listing_buttons hook signature changed](https://docs.wagtail.org/en/latest/releases/6.1.html#register-user-listing-buttons-hook-signature-changed)
  - [ ] [Password_required_template has changed to wagtail_password_required_template](https://docs.wagtail.org/en/latest/releases/6.1.html#password-required-template-has-changed-to-wagtail-password-required-template)
  - [ ] [Document_password_required_template has changed to wagtaildocs_password_required_template](https://docs.wagtail.org/en/latest/releases/6.1.html#document-password-required-template-has-changed-to-wagtaildocs-password-required-template)
### Changes to undocumented internals
  - [ ] [Deprecation of user_listing_buttons template tag](https://docs.wagtail.org/en/latest/releases/6.1.html#deprecation-of-user-listing-buttons-template-tag)
  - [ ] [Deprecation of wagtailusers_groups:users url pattern](https://docs.wagtail.org/en/latest/releases/6.1.html#deprecation-of-wagtailusers-groups-users-url-pattern)
  - [ ] [Deprecation of window.chooserurls within draftail choosers](https://docs.wagtail.org/en/latest/releases/6.1.html#deprecation-of-window-chooserurls-within-draftail-choosers)
  - [ ] [Deprecation of window.initblockwidget to initialize a streamfield block](https://docs.wagtail.org/en/latest/releases/6.1.html#deprecation-of-window-initblockwidget-to-initialize-a-streamfield-block)
  - [ ] [Old](https://docs.wagtail.org/en/latest/releases/6.1.html#id1)
  - [ ] [New](https://docs.wagtail.org/en/latest/releases/6.1.html#id2)
  - [ ] [Removal of jquery from base client-side widget and boundwidget classes](https://docs.wagtail.org/en/latest/releases/6.1.html#removal-of-jquery-from-base-client-side-widget-and-boundwidget-classes)
  - [ ] [Window.urlify deprecated](https://docs.wagtail.org/en/latest/releases/6.1.html#window-urlify-deprecated)
  - [ ] [Window.xregexp polyfill removed](https://docs.wagtail.org/en/latest/releases/6.1.html#window-xregexp-polyfill-removed)

</details>